### PR TITLE
Add explicit async function

### DIFF
--- a/test/function.ls
+++ b/test/function.ls
@@ -53,6 +53,10 @@ function main t
   actual = fn!
   t.equal actual, expected, 'wrap only statement of bound functions'
 
+  fn = async ->
+  actual = fn!
+  t.ok actual.then 'explicit async functions'
+
   expected = -> await expected
   actual = expected!
   t.ok actual.then, 'the async function returns a Promise'


### PR DESCRIPTION
See #2.

Allow explicitly marking functions as async like JS.

```ls
async ->
async ~>
async function =>
```
compiles to
```js
(async function () {});
async () => {};
(async function () {});
```

`async` is optional, usage of `await` still mark async function implicitly.

@gkovacs Any notes?