### PR TITLE
Allow destructuring in all comprehensions, fix #4

### DIFF
--- a/src/convert.ls
+++ b/src/convert.ls
@@ -701,7 +701,7 @@ t <<<
   Assign: define \AssignmentExpression \pass \lval \expression
   Splat: define \SpreadElement \expression
 
-  Vars: define \declare \pass
+  Vars: define \declare \lval
   Block: define \BlockStatement \statement
   Sequence: define \SequenceExpression
 

--- a/test/loop.ls
+++ b/test/loop.ls
@@ -33,6 +33,15 @@ function main t
   expected = 0: 0 1: 2 2: 4 3: 6
   t.deep-equal actual, expected, 'object comprehension with iteration'
 
+  source =
+    * a: [\x]
+    * a: [\y]
+
+  actual = [b for {a: [b]} in source]
+  expected = [\x \y]
+  t.deep-equal actual, expected,
+  'destructuring in comprehension with iterables'
+
   t.end!
 
 export default: main


### PR DESCRIPTION
Fix destructuring in `for ... in` comprehensions(#4).

This is cause by incorrect node type in loop variable declarations.
Nodes in variable declarations should be treated as `LVal`, so that they are converted to correct type for declaration.