### PR TITLE
Add generator function and yield expression support

### DIFF
--- a/test/generator.ls
+++ b/test/generator.ls
@@ -1,0 +1,14 @@
+function main t
+  gen = ->
+    yield
+    yield 1
+    yield from [2 3]
+  q = gen!
+  actual = Array.from length: 5 .map -> q.next!value
+  expected = [void 1 2 3 void]
+  t.deep-equal actual, expected, 'generator function and yield'
+
+  t.end!
+
+export default: main
+

--- a/test/generator.ls
+++ b/test/generator.ls
@@ -8,6 +8,17 @@ function main t
   expected = [void 1 2 3 void]
   t.deep-equal actual, expected, 'generator function and yield'
 
+  ~function gen1 a, b
+    yield 1
+    yield @
+    yield 2
+    yield gen1
+
+  q = gen1!
+  actual = Array.from length: 5 .map -> q.next!value
+  expected = [1 @, 2 gen1, void]
+  t.deep-equal actual, expected, 'bound generator'
+
   t.end!
 
 export default: main

--- a/test/index.ls
+++ b/test/index.ls
@@ -1,6 +1,6 @@
 import tape: test, \./module : module$, \./function : func,
   \./assign : assign, \./literal : literal, \./if : if$,
-  \./loop : loop$
+  \./loop : loop$, \./generator : generator
   \./operator : operator, \./chain : chain, \./switch : switch$
   \./try : try$
 
@@ -14,3 +14,4 @@ test chain, \Chain
 test loop$, \Loop
 test switch$, \Switch
 test try$, \Try
+test generator, \Generator


### PR DESCRIPTION
Fix #5.

```ls
->
  yield
  yield 1
  yield from [2 3]
```
```js
(function* () {
  yield;
  yield 1;
  return yield* [2, 3];
});
```

`yield` implicitly marks functions as generator like `await` does, `->*` are `function*` are also supported.

This also enables [async generator functions](/tc39/proposal-async-iteration#async-generator-functions), but not bound generator `~>*`.

Bound functions `~>` are converted to arrow functions `=>`, but [arrow functions cannot be used as generators](//stackoverflow.com/a/34108006) directly.

```ls
~function* gen a, b
  yield a b
```

There various options to work around:

**0. Use additional variables to bind `this`**
```js
let this$ = this
function* gen(a, b){
  return yield a(b)
}
```

**1. Wrap with IIFE**
```js
let gen = (a, b) => (function*() {
  return yield a(b)
}).call(this)
```

**2. Use bind**
```js
let gen = (function*(a, b) {
  return yield a(b)
}).bind(this)
```

Laugh for 0, hooray for 1, heart for 2 and comment for your ideas.